### PR TITLE
Run every 15 mins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,5 +51,23 @@ workflows:
             branches:
               only:
                 - master
+      - schedule:
+          cron: "15 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+      - schedule:
+          cron: "30 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+      - schedule:
+          cron: "45 * * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - reap


### PR DESCRIPTION
This way downstream consumers can have more up to date information about the status of the total repodata.json