### PR TITLE
write out file listing for 3rd party raw access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
             python -m libcflib.harvest_pkgs
           no_output_timeout: 60m
       - run:
+          name: list files
+          command: |
+            xonsh -c "import json; json.dump(g`artifacts/**`, open('.file_listing.json', 'w'), indent=2)"
+      - run:
           name: Report diff
           command: |
             git add .


### PR DESCRIPTION
This will enable us random access to the files in this db (rather than pulling the entire repo).
That access will help us fine tune our conda-forge <-> import mapping and API bounding via exported files.

@scopatz @mariusvniekerk @beckermr